### PR TITLE
Arrumando nome da constante para o import funcionar.

### DIFF
--- a/src/validator/idValidator.js
+++ b/src/validator/idValidator.js
@@ -1,5 +1,5 @@
 import { param } from 'express-validator'
 
-export const idItensPedidosValidator = [
+export const idValidator = [
     param('id').isInt().withMessage("Id não foi passado ou não é um número inteiro"),
 ]


### PR DESCRIPTION
# Arrumando o nome da constante

O nome que estava sendo importado era `idValidator`, mas o nome da constante era `idItensPedidosValidator`.

## _*Antes:*_

```Javascript

export const idItensPedidosValidator = [
    param('id').isInt().withMessage("Id não foi passado ou não é um número inteiro"),
]

```

## _*Depois:*_

```Javascript

export const idValidator = [
    param('id').isInt().withMessage("Id não foi passado ou não é um número inteiro"),
]

```